### PR TITLE
Add bind settings for simple (user/pass) and test calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,10 @@ django-pucas
 .. image:: https://landscape.io/github/Princeton-CDH/django-pucas/develop/landscape.svg?style=flat
    :target: https://landscape.io/github/Princeton-CDH/django-pucas/develop
    :alt: Code Health
-   
+
 .. image:: https://requires.io/github/Princeton-CDH/django-pucas/requirements.svg?branch=develop
      :target: https://requires.io/github/Princeton-CDH/django-pucas/requirements/?branch=develop
-     :alt: Requirements Status   
+     :alt: Requirements Status
 
 **django-pucas** is a reusable `Django`_ application to simplify logging
 into a Django application with CAS using `django-cas-ng`_.  Login and
@@ -97,8 +97,13 @@ Add required configurations to ``settings.py``:
         # not handled by attribute map.  Method should take a user
         # object and ldap search result.
         'EXTRA_USER_INIT': 'myproj.myapp.models.init_profile_from_ldap'
+        'BASE_DN': 'uid=username,o=your org,c=country_code',
+        'BASE_PASSWORD': 'secreupasswordforyourldap',
     }
 
+* Note: ``BASE_DN`` and ``BASE_PASSWORD`` are optional if you want
+        to bind anonymously. Add them if they are required by your LDAP.
+        This supports user/pass authentication, but not yet uid only.
 
 Run migrations to create database tables required by django-cas-ng::
 

--- a/pucas/ldap.py
+++ b/pucas/ldap.py
@@ -25,16 +25,16 @@ class LDAPSearch(object):
             ldap3.ROUND_ROBIN, active=True, exhaust=5)
 
         # Load username (in DN format) and password, if in settings
-        DN = settings.PUCAS_LDAP.get('DN', None)
-        password = settings.PUCAS_LDAP.get('PASSWORD', None)
+        bind_dn = settings.PUCAS_LDAP.get('BIND_DN', None)
+        bind_password = settings.PUCAS_LDAP.get('BIND_PASSWORD', None)
 
         # If DN and password exist, use them. Otherwise, try an anon bind
-        if DN and password:
+        if bind_dn and bind_password:
             try:
                 self.conn = ldap3.Connection(
                     server_pool,
-                    user=DN,
-                    password=password,
+                    user=bind_dn,
+                    password=bind_password,
                     auto_bind=True
                 )
             except LDAPException as err:

--- a/pucas/tests.py
+++ b/pucas/tests.py
@@ -62,6 +62,36 @@ class TestLDAPSearch(TestCase):
             mockldap3.Connection.side_effect = LDAPException
             LDAPSearch()
 
+    dn = 'uid=foo,o=bar organization,cn=us'
+
+    @mock.patch('pucas.ldap.ldap3')
+    @override_settings(PUCAS_LDAP={'SERVERS': ldap_servers, 'DN': dn, 'PASSWORD': 'baz'})
+    def test_simple_bind_init(self, mockldap3):
+        # initialize and then check expected behavior against
+        # mock ldap3
+        LDAPSearch()
+
+        test_servers = []
+        for test_server in self.ldap_servers:
+            mockldap3.Server.assert_any_call(test_server,
+                get_info=mockldap3.ALL, use_ssl=True)
+
+        # initialized servers are collected into server pool
+        servers = [mockldap3.Server.return_value
+                   for test_server in self.ldap_servers]
+        mockldap3.ServerPool.assert_called_with(servers,
+            mockldap3.ROUND_ROBIN, active=True, exhaust=5)
+
+        # server pool is used for connection
+        mockldap3.Connection.assert_called_with(mockldap3.ServerPool.return_value,
+            auto_bind=True, user=self.dn, password='baz')
+
+        with pytest.raises(LDAPException):
+            mockldap3.Connection.side_effect = LDAPException
+            LDAPSearch()
+
+
+
     @mock.patch('pucas.ldap.ldap3')
     @override_settings(PUCAS_LDAP={'SERVERS': ldap_servers,
         'ATTRIBUTES': ['uid', 'sn', 'ou'],


### PR DESCRIPTION
Added simple bind functionality to pucas -- along with mock tests to ensure a call using those settings is made as expected (i.e. are there user and pass settings? If so, use them.)