### PR TITLE
Fallback LDAP attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ env:
 
 matrix:
   exclude:
-    - python: 2.7
+    - python: "2.7"
       env: DJANGO=2.0
-    - python: 2.7
+    - python: "2.7"
       env: DJANGO=2.1
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,15 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 
 env:
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
+  - DJANGO=1.11
+  - DJANGO=2.0
+  - DJANGO=2.1
 
 before_install:
   - pip install --upgrade pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ env:
   - DJANGO=2.0
   - DJANGO=2.1
 
+matrix:
+  exclude:
+    - python: 2.7
+      env: DJANGO=2.0
+    - python: 2.7
+      env: DJANGO=2.1
+
 before_install:
   - pip install --upgrade pytest
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ CHANGELOG
 
 0.6
 -----
-* Add support for multiple fallbacks on LDAP attributes See (PR #3)[https://github.com/Princeton-CDH/django-pucas/pull/3]
+* Add support for multiple fallbacks on LDAP attributes. See `PR #3<https://github.com/Princeton-CDH/django-pucas/pull/>`_.
 * Improve handling for missing LDAP attributes.
 * Document tested Django and Python versions.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,6 @@ CHANGELOG
 * Improve handling for missing LDAP attributes.
 * Document tested Django and Python versions.
 
-
 0.5.2
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.6
+-----
+* Add support for multiple fallbacks on LDAP attributes See (PR #3)[https://github.com/Princeton-CDH/django-pucas/pull/3]
+* Improve handling for missing LDAP attributes.
+* Document tested Django and Python versions.
+
+
 0.5.2
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ CHANGELOG
 
 0.6
 -----
-* Add support for multiple fallbacks on LDAP attributes. See `PR #3<https://github.com/Princeton-CDH/django-pucas/pull/>`_.
+* Add support for multiple fallbacks on LDAP attributes. See `PR #3 <https://github.com/Princeton-CDH/django-pucas/pull/>`_.
 * Improve handling for missing LDAP attributes.
 * Document tested Django and Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -88,10 +88,12 @@ Add required configurations to ``settings.py``:
         # attributes to request from the LDAP server
         'ATTRIBUTES': ['givenName', 'sn', 'mail'],
         # mapping of User attributes to LDAP attributes
+        # if passed list for the value, the first attribute to return a
+        # value will be used
         'ATTRIBUTE_MAP': {
             'first_name': 'givenName',
             'last_name': 'sn',
-            'email': 'mail'
+            'email': ['mail', 'eduPerson']
         },
         # Optional local method to do additional user initialization
         # not handled by attribute map.  Method should take a user
@@ -187,4 +189,3 @@ License
 Princeton Docket #18-3398-1 for distribution online under a standard Open Source
 license.  Ownership rights transferred to Rebecca Koeser provided software
 is distributed online via open source.
-

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,11 @@ support for prepopulating user account data based on an LDAP search.
 .. _Django: https://www.djangoproject.com/
 .. _django-cas-ng: https://github.com/mingchen/django-cas-ng
 
+**django-pucas** is tested under:
+
+* Django ``1.8-2.1``
+* Python ``2.7, 3.5, 3.6`` (excluding ``2.7`` for Django ``2+``)
+
 Installation
 ------------
 

--- a/pucas/ldap.py
+++ b/pucas/ldap.py
@@ -85,15 +85,17 @@ def user_info_from_ldap(user):
     if user_info:
         for user_attr, ldap_attr in attr_map.items():
             # Handle issues where an attribute may need to be populated by
-            # multiple attributes OR where it is missing, in which case
-            # handle the LDAPCursorError and set None to empty string.
+            # multiple attributes OR where it is missing.
 
-            # if just a string, convert to a list so handling can be uniform
+            # if just a string, convert to a list so handling can be uniform,
+            # in cases where a field is multivalued.
             if isinstance(ldap_attr, str):
                 ldap_attr = [ldap_attr]
 
             # iterate through the list items and break on the first one to
             # correct set without raising LDAPCursorError
+            # This is a simplification for multivalued fields, since
+            # typically we're mapping to only one value.
             for val in ldap_attr:
                 try:
                     setattr(user, user_attr, str(getattr(user_info, val)))
@@ -101,7 +103,9 @@ def user_info_from_ldap(user):
                 except LDAPCursorError:
                     pass
             # user getattr to check for a still unset value, in which case
-            # set it to an empty string
+            # set it to an empty string, used in situations where
+            # a user is being updated -- and ot make sure values are
+            # strings, not lists
             if not getattr(user, user_attr, None):
                 setattr(user, user_attr, '')
 

--- a/pucas/ldap.py
+++ b/pucas/ldap.py
@@ -89,7 +89,7 @@ def user_info_from_ldap(user):
             # handle the LDAPCursorError and set None to empty string.
 
             # if the user passed a list, try in order until we get the attr
-            # or we fail to do so, in which case, continue on for now
+            # or we fail to do so.
             if isinstance(ldap_attr, list):
                 for val in ldap_attr:
                     try:

--- a/pucas/ldap.py
+++ b/pucas/ldap.py
@@ -78,7 +78,8 @@ def user_info_from_ldap(user):
     # if no map is configured, nothing to do
     if not attr_map:
         # is logging sufficient here? or should it be an exception
-        logging.warn('No attribute map configured; not populating user info from ldap')
+        logging.warning('No attribute map configured; not populating user info'
+                        ' from ldap')
         return
 
     user_info = LDAPSearch().find_user(user.username)

--- a/pucas/tests.py
+++ b/pucas/tests.py
@@ -119,8 +119,7 @@ class TestLDAPSearch(TestCase):
 
         with pytest.raises(LDAPSearchException) as search_err:
             ldsearch.find_user(netid)
-
-        assert 'No match found for %s' % netid in str(search_err)
+        assert 'No match found for %s' % netid in str(search_err.value)
         # search should use configured values
         ldsearch.conn.search.assert_called_with(settings.PUCAS_LDAP['SEARCH_BASE'],
             settings.PUCAS_LDAP['SEARCH_FILTER'] % {'user': netid},
@@ -131,7 +130,8 @@ class TestLDAPSearch(TestCase):
         with pytest.raises(LDAPSearchException) as search_err:
             ldsearch.find_user(netid)
 
-        assert 'Found more than one entry for %s' % netid in str(search_err)
+        assert 'Found more than one entry for %s' % netid in \
+            str(search_err.value)
 
         # simulate one match
         userinfo = mock.Mock()
@@ -162,7 +162,7 @@ class TestLDAPSearch(TestCase):
             with override_settings(PUCAS_LDAP=bad_cfg):
                 with pytest.raises(LDAPSearchException) as search_err:
                     ldsearch.find_user(netid)
-            assert 'LDAP is not configured for user lookup' in str(search_err)
+            assert 'LDAP is not configured for user lookup' in str(search_err.value)
 
 
 def extra_user_init(user, user_info):

--- a/pucas/tests.py
+++ b/pucas/tests.py
@@ -23,7 +23,7 @@ class MockLDAPInfo(object):
         for k, v in kwargs.items():
             setattr(self, k, v)
     def __getattr__(self, attr):
-        # __getattr__ only gets called when the default attribue access
+        # __getattr__ only gets called when the default attribute access
         # falls through, so in this case, we always want that to raise the
         # cursor error
         raise LDAPCursorError

--- a/pucas/tests.py
+++ b/pucas/tests.py
@@ -8,13 +8,36 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.utils.six import StringIO
-from ldap3.core.exceptions import LDAPException
+from ldap3.core.exceptions import LDAPException, LDAPCursorError
 import pytest
 
 from pucas.ldap import LDAPSearch, LDAPSearchException, \
     user_info_from_ldap
 from pucas.signals import cas_login
 from pucas.management.commands import ldapsearch, createcasuser
+
+
+class MockLDAPInfo(object):
+    '''Simulate ldap result object with ldap3 specific behavior for getattr'''
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+    def __getattr__(self, attr):
+        if attr in self.__dict__:
+            return self.__dict__[attr]
+        raise LDAPCursorError
+
+class TestMockLDAPInfo(TestCase):
+
+    def test_init(self):
+        mock_info = MockLDAPInfo(a=1, b=2)
+        assert mock_info.a == 1
+        assert mock_info.b == 2
+
+    def test_getattr(self):
+        mock_info = MockLDAPInfo(a=1, b=2)
+        with pytest.raises(LDAPCursorError):
+            foo = mock_info.c
 
 
 class TestSignals(TestCase):
@@ -149,7 +172,7 @@ def extra_user_init(user, user_info):
 class TestUserInfo(TestCase):
 
     test_attr_map = {'first_name': 'givenName', 'last_name': 'surname',
-        'email': 'mail'}
+                     'email': ['mail', 'eduPerson']}
 
     @override_settings(PUCAS_LDAP={})
     def test_no_attrs(self, mock_ldapsearch):
@@ -172,14 +195,39 @@ class TestUserInfo(TestCase):
         # user save should not be called - no data
         mockuser.save.assert_not_called()
 
-        # simulate user info returned
-        mock_ldapinfo = mock.Mock(givenName='John', surname='Doe',
-            mail='jdoe@example.com', extra='foo')
+        mock_ldapinfo = MockLDAPInfo(
+                        eduPerson='jdoe2@example.com', givenName='John', surname='Doe',
+                        mail='jdoe@example.com', extra='foo'
+                    )
+        # first test that list style attributes are set in order, and string
+        # attributes are set as given
         mock_ldapsearch.return_value.find_user.return_value = mock_ldapinfo
         user_info_from_ldap(mockuser)
         assert mockuser.first_name == mock_ldapinfo.givenName
         assert mockuser.last_name == mock_ldapinfo.surname
         assert mockuser.email == mock_ldapinfo.mail
+        mockuser.save.assert_called_with()
+
+        # second test that should pass over an unset eduPerson attr and
+        # set using givenName in list
+        # NOTE: recreating mock to clear all assigned attrs
+        mockuser = mock.Mock(username='jdoe')
+        delattr(mock_ldapinfo, 'mail')
+        user_info_from_ldap(mockuser)
+        assert mockuser.first_name == mock_ldapinfo.givenName
+        assert mockuser.last_name == mock_ldapinfo.surname
+        assert mockuser.email == mock_ldapinfo.eduPerson
+        mockuser.save.assert_called_with()
+
+        # missing attribute altogether should result in an empty string
+        delattr(mock_ldapinfo, 'givenName')
+        delattr(mock_ldapinfo, 'surname')
+        mockuser = mock.Mock(username='jdoe')
+        mock_ldapsearch.return_value.find_user.return_value = mock_ldapinfo
+        user_info_from_ldap(mockuser)
+        assert mockuser.first_name == ''
+        assert mockuser.last_name == ''
+        assert mockuser.email == mock_ldapinfo.eduPerson
         mockuser.save.assert_called_with()
 
     @override_settings(PUCAS_LDAP={'ATTRIBUTE_MAP': test_attr_map,
@@ -290,4 +338,3 @@ class TestCreateCasUserCommand(TestCase):
         mock_ldapsearch.return_value.find_user.side_effect = LDAPSearchException
         call_command('createcasuser', 'jdoe', '--staff')
         mock_ldapsearch.return_value.find_user.assert_called_with('jdoe')
-

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-REQUIREMENTS = ['django>=1.8', 'django-cas-ng', 'ldap3']
+REQUIREMENTS = ['django>=1.8,<2.1', 'django-cas-ng', 'ldap3']
 TEST_REQUIREMENTS = ['pytest', 'pytest-django', 'pytest-cov']
 if sys.version_info < (3, 0):
     TEST_REQUIREMENTS.append('mock')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-REQUIREMENTS = ['django>=1.8,<2.1', 'django-cas-ng', 'ldap3']
+REQUIREMENTS = ['django>=1.8', 'django-cas-ng', 'ldap3']
 TEST_REQUIREMENTS = ['pytest', 'pytest-django', 'pytest-cov']
 if sys.version_info < (3, 0):
     TEST_REQUIREMENTS.append('mock')


### PR DESCRIPTION
This pull request allows users to set a list of fall backs for LDAP mappings for Django `User` fields:

* Allow a list to map fallbacks in the `ATTRIBUTE_MAP` setting (taking the first valid hit)
* Improved error handling for `ldap3` idiosyncrasies (handle `LDAPCursorError` and set empty fields to strings)
* ~~Repin requirements to reflect current state of Django compatibility `>=1.8<2.1` (because of `django-cas-ng` issues in `2.1`~~ (Latest now works!)
* Document Django and Python versions subject to test