### PR TITLE
Require (and support) django-cas-ng > 3.6, update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+dist: "xenial"
+
 python:
   - "2.7"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 env:
   - DJANGO=1.8
@@ -12,6 +13,7 @@ env:
   - DJANGO=1.11
   - DJANGO=2.0
   - DJANGO=2.1
+  - DJANGO=2.2
 
 matrix:
   exclude:
@@ -19,6 +21,8 @@ matrix:
       env: DJANGO=2.0
     - python: "2.7"
       env: DJANGO=2.1
+    - python: "2.7"
+      env: DJANGO=2.2
 
 before_install:
   - pip install --upgrade pytest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 * Add support for multiple fallbacks on LDAP attributes. See `PR #3 <https://github.com/Princeton-CDH/django-pucas/pull/>`_.
 * Improve handling for missing LDAP attributes.
-* Add support for (and require) ``django-cas-ng>=3.6``.
+* Now requires django-cas-ng 3.6 or greater.
 * Document tested Django and Python versions.
 
 0.5.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 * Add support for multiple fallbacks on LDAP attributes. See `PR #3 <https://github.com/Princeton-CDH/django-pucas/pull/>`_.
 * Improve handling for missing LDAP attributes.
+* Add support for (and require) ``django-cas-ng>=3.6``.
 * Document tested Django and Python versions.
 
 0.5.2

--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,8 @@ support for prepopulating user account data based on an LDAP search.
 
 **django-pucas** is tested under:
 
-* Django ``1.8-2.1``
-* Python ``2.7, 3.5, 3.6`` (excluding ``2.7`` for Django ``2+``)
+* Django ``1.8-2.2``
+* Python ``2.7, 3.5-3.7`` (excluding ``2.7`` for Django ``2+``)
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,8 @@ support for prepopulating user account data based on an LDAP search.
 * Django ``1.8-2.2``
 * Python ``2.7, 3.5-3.7`` (excluding ``2.7`` for Django ``2+``)
 
+**django-pucas** requires **django-cas-ng** 3.6 or greater.
+
 Installation
 ------------
 

--- a/pucas/cas_urls.py
+++ b/pucas/cas_urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls import url
-from django_cas_ng.views import login, logout, callback
+from django_cas_ng.views import LoginView, LogoutView, CallbackView
 
 urlpatterns = [
-    url(r'^login/$', login, name='cas_ng_login'),
-    url(r'^logout/$', logout, name='cas_ng_logout'),
-    url(r'^callback/$', callback, name='cas_ng_proxy_callback'),
+    url(r'^login/$', LoginView.as_view(), name='cas_ng_login'),
+    url(r'^logout/$', LogoutView.as_view(), name='cas_ng_logout'),
+    url(r'^callback/$', CallbackView.as_view(), name='cas_ng_proxy_callback'),
 ]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-REQUIREMENTS = ['django>=1.8', 'django-cas-ng', 'ldap3']
+REQUIREMENTS = ['django>=1.8', 'django-cas-ng>=3.6', 'ldap3']
 TEST_REQUIREMENTS = ['pytest', 'pytest-django', 'pytest-cov']
 if sys.version_info < (3, 0):
     TEST_REQUIREMENTS.append('mock')
@@ -38,6 +38,10 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
@@ -46,6 +50,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: System :: Systems Administration :: Authentication/Directory',
         'Topic :: System :: Systems Administration :: Authentication/Directory :: LDAP',


### PR DESCRIPTION
This PR:
- Adds support for django-cas-ng 3.6's class-based views (#4)
- Updates testing matrix for new Python and Django versions, and documents this fact.
- Documents changes to requirements in `CHANGELOG` and includes them in setup.py.
