### PR TITLE
Feature/update python

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django: ["3.2", "4.0", "4.1", "4.2"]
     steps:
       - name: Checkout repository

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ support for prepopulating user account data based on an LDAP search.
 **django-pucas** is tested against:
 
 * Django ``3.2-4.0``
-* Python ``3.9-3.11``
+* Python ``3.10-3.14``
 
 **django-pucas** requires **django-cas-ng** 3.6 or greater.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache License, Version 2.0" }
 authors = [
     { name = "CDH @ Princeton", email = "digitalhumanities@princeton.edu" }
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "django>=1.8",
     "django-cas-ng>=3.6",
@@ -29,9 +29,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: System :: Systems Administration :: Authentication/Directory",


### PR DESCRIPTION
**Associated Issue(s):** resolves #18 

### Changes in this PR
- Dropped Python `3.9` support in project metadata and removed the `3.9` classifier.
- Added Python 3.12–3.14 classifiers in `pyproject.toml`.
- - Updated release publish workflow to use Python `3.12`.
- Updated CI unit test matrix to run on Python `3.10–3.14`. (Do we want to limit it to just 3.12-3.14 instead?)
- Updated README tested-Python range to `3.10-3.14`.

### Notes


### Reviewer Checklist
- [x] Review the code changes
